### PR TITLE
add: zk plonky2 for sudoku

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 [workspace]
 members = [
     "polynomial",
-    "univariate-polynomial-iop-zerotest"
+    "univariate-polynomial-iop-zerotest",
+    "zk-plonky2-sudoku",
 ]
 resolver = "2"
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,1 @@
+nightly

--- a/zk-plonky2-sudoku/Cargo.toml
+++ b/zk-plonky2-sudoku/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+edition = "2021"
+name = "zk-plonky2-sudoku"
+version = "0.1.0"
+
+[dependencies]
+plonky2 = "0.2.0"
+plonky2_field = "0.2.0"

--- a/zk-plonky2-sudoku/Cargo.toml
+++ b/zk-plonky2-sudoku/Cargo.toml
@@ -4,5 +4,7 @@ name = "zk-plonky2-sudoku"
 version = "0.1.0"
 
 [dependencies]
+anyhow = "1.0.81"
 plonky2 = "0.2.0"
 plonky2_field = "0.2.0"
+plonky2_waksman = {git = "https://github.com/0xPolygonZero/plonky2-waksman"}

--- a/zk-plonky2-sudoku/src/lib.rs
+++ b/zk-plonky2-sudoku/src/lib.rs
@@ -1,0 +1,52 @@
+use plonky2::{
+    iop::witness::{PartialWitness, WitnessWrite},
+    plonk::{
+        circuit_builder::CircuitBuilder,
+        circuit_data::CircuitConfig,
+        config::{GenericConfig, PoseidonGoldilocksConfig},
+    },
+};
+use plonky2_field::types::Field;
+
+pub fn circuit_builder() {
+    const D: usize = 2;
+    type C = PoseidonGoldilocksConfig;
+    type F = <C as GenericConfig<D>>::F;
+
+    let cfg = CircuitConfig::standard_recursion_config();
+    let mut builder = CircuitBuilder::<F, D>::new(cfg);
+
+    let initial = builder.add_virtual_target();
+    let mut cur_target = initial;
+
+    for i in 1..101 {
+        let i_target = builder.constant(F::from_canonical_u32(i));
+        let n_plus_i = builder.add(initial, i_target);
+        cur_target = builder.mul(cur_target, n_plus_i);
+    }
+
+    builder.register_public_input(initial);
+
+    let mut pw = PartialWitness::new();
+    pw.set_target(initial, F::ONE);
+
+    let data = builder.build::<C>();
+    let proof = data.prove(pw).unwrap();
+
+    println!(
+        "Factorial starting at {} is {}",
+        proof.public_inputs[0], proof.public_inputs[1]
+    );
+
+    data.verify(proof).unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ensure_facts() {
+        circuit_builder()
+    }
+}

--- a/zk-plonky2-sudoku/src/lib.rs
+++ b/zk-plonky2-sudoku/src/lib.rs
@@ -1,5 +1,9 @@
+use anyhow::Result;
 use plonky2::{
-    iop::witness::{PartialWitness, WitnessWrite},
+    iop::{
+        target::Target,
+        witness::{PartialWitness, WitnessWrite},
+    },
     plonk::{
         circuit_builder::CircuitBuilder,
         circuit_data::CircuitConfig,
@@ -8,37 +12,64 @@ use plonky2::{
 };
 use plonky2_field::types::Field;
 
-pub fn circuit_builder() {
+pub fn circuit_builder() -> Result<()> {
     const D: usize = 2;
     type C = PoseidonGoldilocksConfig;
     type F = <C as GenericConfig<D>>::F;
 
+    // 100 bits of security standard recursion config
     let cfg = CircuitConfig::standard_recursion_config();
     let mut builder = CircuitBuilder::<F, D>::new(cfg);
 
-    let initial = builder.add_virtual_target();
-    let mut cur_target = initial;
+    // Add 81 virtual targets (from 0 to 80), these will show up as
+    // Target::VirtualTarget { index: row*9 + col} in sudoku
+    let targets: Vec<Target> = (0..81).map(|_| builder.add_virtual_target()).collect();
 
-    for i in 1..101 {
-        let i_target = builder.constant(F::from_canonical_u32(i));
-        let n_plus_i = builder.add(initial, i_target);
-        cur_target = builder.mul(cur_target, n_plus_i);
-    }
+    let constants_0_to_9: Vec<Target> = (0..9).map(|i| builder.constant(F::from(i + 1))).collect();
 
-    builder.register_public_input(initial);
+    // Constraint: each row should have a values 1 through 9
+    // This is checked via a permuation check on constants 0-9
+    (0..9).for_each(|row| {
+        assert_permutation_circuit(builder, constants_0_to_9, targets[row * 9..(row + 1) * 9])
+    });
 
-    let mut pw = PartialWitness::new();
-    pw.set_target(initial, F::ONE);
+    // plonky2_waksman::permutation::assert_permutation_circuit(builder, a, b);
 
-    let data = builder.build::<C>();
-    let proof = data.prove(pw).unwrap();
+    // Add constraints: Each row should have
+    println!("{:#?}", targets);
 
-    println!(
-        "Factorial starting at {} is {}",
-        proof.public_inputs[0], proof.public_inputs[1]
-    );
+    Ok(())
+    // let initial_a = builder.add_virtual_target();
+    // let initial_b = builder.add_virtual_target();
 
-    data.verify(proof).unwrap()
+    // // println!("{:#?}", initial_b);
+
+    // let mut prev_target = initial_a;
+    // let mut cur_target = initial_b;
+    // for _ in 0..99 {
+    //     let temp = builder.add(prev_target, cur_target);
+    //     prev_target = cur_target;
+    //     cur_target = temp;
+    // }
+
+    // // Public inputs are the two initial values (provided below) and the result (which is generated).
+    // builder.register_public_input(initial_a);
+    // builder.register_public_input(initial_b);
+    // builder.register_public_input(cur_target);
+
+    // let mut pw = PartialWitness::new();
+    // pw.set_target(initial_a, F::ZERO);
+    // pw.set_target(initial_b, F::ONE);
+
+    // let data = builder.build::<C>();
+    // let proof = data.prove(pw)?;
+
+    // println!(
+    //     "100th Fibonacci number mod |F| (starting with {}, {}) is: {}",
+    //     proof.public_inputs[0], proof.public_inputs[1], proof.public_inputs[2]
+    // );
+
+    // data.verify(proof)
 }
 
 #[cfg(test)]
@@ -47,6 +78,6 @@ mod tests {
 
     #[test]
     fn ensure_facts() {
-        circuit_builder()
+        circuit_builder().unwrap()
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Set the Rust toolchain version to `nightly`.
	- Introduced a function to construct a Plonk circuit for verifying Sudoku constraints using the Plonky2 library.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->